### PR TITLE
fix: uri parsing

### DIFF
--- a/android/src/main/java/expo/modules/textextractor/ExpoTextExtractorModule.kt
+++ b/android/src/main/java/expo/modules/textextractor/ExpoTextExtractorModule.kt
@@ -8,6 +8,7 @@ import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import androidx.core.net.toUri
 import java.io.File
 
 class ExpoTextExtractorModule : Module() {
@@ -21,14 +22,10 @@ class ExpoTextExtractorModule : Module() {
     AsyncFunction("extractTextFromImage") { uriString: String, promise: Promise ->
       try {
         val context = appContext.reactContext!!
-        val uri = if (uriString.startsWith("content://")) {
-          Uri.parse(uriString)
-        } else {
-          val file = File(uriString)
-          if (!file.exists()) {
-            throw Exception("File not found: $uriString")
-          }
-          Uri.fromFile(file)
+        val uri = when {
+          uriString.startsWith("file://") -> uriString.toUri()
+          uriString.startsWith("content://") -> uriString.toUri()
+          else -> Uri.fromFile(File(uriString))
         }
 
         val inputImage = InputImage.fromFilePath(context, uri)

--- a/ios/ExpoTextExtractorModule.swift
+++ b/ios/ExpoTextExtractorModule.swift
@@ -2,6 +2,10 @@ import ExpoModulesCore
 import Vision
 
 public class ExpoTextExtractorModule: Module {
+    enum ExtractorError: Error {
+        case invalidImage
+    }
+
     public func definition() -> ModuleDefinition {
         Name("ExpoTextExtractor")
 
@@ -14,7 +18,7 @@ public class ExpoTextExtractorModule: Module {
                 let imageData = try Data(contentsOf: url)
                 let image = UIImage(data: imageData)
                 guard let cgImage = image?.cgImage else {
-                    throw Exception.init(name: "err", description: "err")
+                    throw ExtractorError.invalidImage
                 }
 
                 let requestHandler = VNImageRequestHandler(cgImage: cgImage)


### PR DESCRIPTION
# Description
Fixes handling a raw path like: _/data/user/0/expo.modules.textextractor.example/cache/mrousavy18855351563162681912.jpg_ on Android. Also adds a few error messages.

<img width="270" height="606" alt="Screenshot_1762709566" src="https://github.com/user-attachments/assets/0e6749f0-fde0-4e8f-964b-c629f52faa74" />

<!--- Describe your changes in detail -->

## Related Issues
Closes #17
<!--- If this PR is related to any GH Issue, link the issue here and eventually close/mention/.. it -->

## I have tested my change on

### iOS

- [x] Mobile simulator
- [ ] Mobile device

### Android

- [x] Mobile simulator
- [ ] Mobile device

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.3--canary.18.02a2061.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install expo-text-extractor@0.2.3--canary.18.02a2061.0
  # or 
  yarn add expo-text-extractor@0.2.3--canary.18.02a2061.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of text extraction from images with enhanced URI handling and file validation.
  * Enhanced error messages when image extraction fails, providing clearer feedback on extraction issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->